### PR TITLE
fix bug: synthesized retain overiwiret system retain

### DIFF
--- a/Classes/MosquittoMessage.h
+++ b/Classes/MosquittoMessage.h
@@ -15,7 +15,7 @@
     NSString *payload;
     unsigned short payloadlen;
     unsigned short qos;
-    BOOL retain;
+    BOOL retained;
 }
 
 
@@ -24,7 +24,7 @@
 @property (readwrite, retain) NSString *payload;
 @property (readwrite, assign) unsigned short payloadlen;
 @property (readwrite, assign) unsigned short qos;
-@property (readwrite, assign) BOOL retain;
+@property (readwrite, assign) BOOL retained;
 
 -(id)init;
 

--- a/Classes/MosquittoMessage.m
+++ b/Classes/MosquittoMessage.m
@@ -10,7 +10,7 @@
 
 @implementation MosquittoMessage
 
-@synthesize mid, topic, payload, payloadlen, qos, retain;
+@synthesize mid, topic, payload, payloadlen, qos, retained;
 
 -(id)init
 {
@@ -19,7 +19,7 @@
     self.payload = nil;
     self.payloadlen = 0;
     self.qos = 0;
-    self.retain = FALSE;
+    self.retained = FALSE;
     return self;
 }
 


### PR DESCRIPTION
This problem will cause that we cannot send the real retain (for add the  reference count) message to MosiquittoMessage object.
